### PR TITLE
fix(ci): resolve NPM authentication error in build-and-release workflow

### DIFF
--- a/.github/NPM_TOKEN_SETUP.md
+++ b/.github/NPM_TOKEN_SETUP.md
@@ -1,0 +1,107 @@
+# 🔐 Configuração do NPM_TOKEN para Publicação Automática
+
+Este documento explica como configurar o `NPM_TOKEN` para habilitar a publicação automática de pacotes no NPM através do GitHub Actions.
+
+## 📋 Pré-requisitos
+
+- Conta no [NPM](https://www.npmjs.com/)
+- Permissões de administrador no repositório GitHub
+- Pacotes configurados com escopo `@cms-nestjs-libs`
+
+## 🚀 Passo a Passo
+
+### 1. Gerar Token de Acesso NPM
+
+1. Acesse [NPM Settings > Access Tokens](https://www.npmjs.com/settings/tokens)
+2. Clique em **"Generate New Token"**
+3. Selecione **"Automation"** como tipo de token
+4. Defina um nome descritivo (ex: `GitHub Actions - NestJS Libs`)
+5. Copie o token gerado (você só verá uma vez!)
+
+### 2. Configurar Secret no GitHub
+
+1. Vá para o repositório no GitHub
+2. Acesse **Settings > Secrets and variables > Actions**
+3. Clique em **"New repository secret"**
+4. Configure:
+   - **Name:** `NPM_TOKEN`
+   - **Secret:** Cole o token NPM gerado
+5. Clique em **"Add secret"**
+
+### 3. Verificar Configuração
+
+Após configurar o secret, o workflow `build-and-release` irá:
+
+✅ **Com NPM_TOKEN configurado:**
+- Verificar autenticação NPM
+- Publicar pacotes automaticamente no NPM
+- Criar releases no GitHub
+
+⚠️ **Sem NPM_TOKEN configurado:**
+- Pular a publicação no NPM
+- Continuar com build e release no GitHub
+- Exibir instruções de configuração
+
+## 🔍 Verificação de Status
+
+O workflow inclui verificação automática do NPM_TOKEN:
+
+```yaml
+- name: Check NPM Authentication
+  id: npm-auth-check
+  run: |
+    if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+      echo "⚠️  NPM_TOKEN not configured in repository secrets"
+      echo "npm-auth-available=false" >> $GITHUB_OUTPUT
+    else
+      echo "✅ NPM_TOKEN is configured"
+      echo "npm-auth-available=true" >> $GITHUB_OUTPUT
+    fi
+```
+
+## 🛡️ Segurança
+
+- **Nunca** compartilhe o token NPM
+- **Nunca** commite o token no código
+- Use apenas tokens do tipo **"Automation"**
+- Revogue tokens não utilizados
+- Monitore o uso dos tokens no NPM
+
+## 🔧 Troubleshooting
+
+### Erro: `ENEEDAUTH`
+```
+npm error code ENEEDAUTH
+npm error need auth This command requires you to be logged in
+```
+
+**Solução:** Verifique se o `NPM_TOKEN` está configurado corretamente nos secrets do repositório.
+
+### Erro: `E403`
+```
+npm error code E403
+npm error 403 Forbidden
+```
+
+**Possíveis causas:**
+- Token NPM expirado ou inválido
+- Falta de permissão para publicar no escopo `@cms-nestjs-libs`
+- Versão do pacote já existe no NPM
+
+### Erro: `E404`
+```
+npm error code E404
+npm error 404 Not Found
+```
+
+**Solução:** Verifique se o escopo `@cms-nestjs-libs` existe e você tem permissão para publicar nele.
+
+## 📚 Links Úteis
+
+- [NPM Access Tokens](https://docs.npmjs.com/about-access-tokens)
+- [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- [NPM Publishing](https://docs.npmjs.com/cli/v8/commands/npm-publish)
+
+---
+
+**Nota:** Este documento faz parte da configuração de CI/CD do projeto NestJS Libraries.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -209,12 +209,35 @@ jobs:
           git push origin HEAD:main
           echo "Created and pushed tag: $tag_name"
 
+      - name: Check NPM Authentication
+        id: npm-auth-check
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "⚠️  NPM_TOKEN not configured in repository secrets"
+            echo "📝 To enable NPM publishing, add NPM_TOKEN to repository secrets"
+            echo "npm-auth-available=false" >> $GITHUB_OUTPUT
+          else
+            echo "✅ NPM_TOKEN is configured"
+            echo "npm-auth-available=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to NPM
+        if: steps.npm-auth-check.outputs.npm-auth-available == 'true'
         run: |
           cd libs/${{ matrix.lib }}/dist
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: NPM Publishing Skipped
+        if: steps.npm-auth-check.outputs.npm-auth-available == 'false'
+        run: |
+          echo "🚫 NPM publishing skipped - NPM_TOKEN not configured"
+          echo "📦 Package built successfully but not published to NPM"
+          echo "🔧 To enable NPM publishing:"
+          echo "   1. Generate an NPM access token at https://www.npmjs.com/settings/tokens"
+          echo "   2. Add it as NPM_TOKEN in repository secrets"
+          echo "   3. Re-run this workflow"
 
       - name: Create GitHub Release
         uses: actions/create-release@v1
@@ -236,6 +259,18 @@ jobs:
           echo "- **New Version:** ${{ steps.new-version.outputs.new-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Version Bump Type:** ${{ steps.version-bump.outputs.version-type }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag:** ${{ matrix.lib }}-v${{ steps.new-version.outputs.new-version }}" >> $GITHUB_STEP_SUMMARY
+          
+          # NPM Publishing Status
+          if [ "${{ steps.npm-auth-check.outputs.npm-auth-available }}" = "true" ]; then
+            echo "- **NPM Publishing:** ✅ Published to NPM" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **NPM Publishing:** ⚠️ Skipped (NPM_TOKEN not configured)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### 🔧 NPM Publishing Setup" >> $GITHUB_STEP_SUMMARY
+            echo "To enable NPM publishing, configure NPM_TOKEN in repository secrets." >> $GITHUB_STEP_SUMMARY
+            echo "See [NPM_TOKEN Setup Guide](.github/NPM_TOKEN_SETUP.md) for detailed instructions." >> $GITHUB_STEP_SUMMARY
+          fi
+          
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Release Notes" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.release-notes.outputs.release-notes }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Add NPM_TOKEN availability check before publishing
- Skip NPM publishing gracefully when token is not configured
- Add comprehensive NPM_TOKEN setup documentation
- Improve build summary with NPM publishing status
- Prevent ENEEDAUTH errors in CI/CD pipeline

Fixes NPM publishing failures due to missing authentication token.