### PR TITLE
fix(workflow): correct NPM publish directory to include dist folder

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Publish to NPM
         if: steps.npm-auth-check.outputs.npm-auth-available == 'true'
         run: |
-          cd libs/${{ matrix.lib }}/dist
+          cd libs/${{ matrix.lib }}
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Change npm publish command to run from library root instead of dist folder
- This ensures the package.json "files" configuration properly includes the dist folder
- Fixes issue where dist folder was not being published to NPM registry
- Previous manual publication (v0.0.2) worked because it included dist folder